### PR TITLE
stages: add support for controller_type 27 (KDC101)

### DIFF
--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -20,7 +20,7 @@ def stage_name_from_get_hw_info(m):
             return 'HS ZST6(B)'
         else:
             return 'ZST6(B)'
-    elif controller_type in (63, 83):
+    elif controller_type in (27, 63, 83):
         #Info obtained from thorlabs technical support
         if stage_type == 0x01:
             _print_stage_detection_improve_message(m)


### PR DESCRIPTION
Follow-up on my email. This adds support for the KDC101 controller. The stage types seem to be the same on this device, at least 0x8 is indeed MTS50-Z8.